### PR TITLE
Speed up asciidoc compilation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-asciidoc "0.1.1"
+(defproject cryogen-asciidoc "0.1.2-SNAPSHOT"
   :description "AsciiDoc parser for Cryogen"
   :url "https://github.com/cryogen-project/cryogen-asciidoc"
   :license {:name "Eclipse Public License"

--- a/src/cryogen_asciidoc/core.clj
+++ b/src/cryogen_asciidoc/core.clj
@@ -24,4 +24,3 @@
 
 (defn init []
   (swap! markup-registry conj (asciidoc)))
-

--- a/src/cryogen_asciidoc/core.clj
+++ b/src/cryogen_asciidoc/core.clj
@@ -5,6 +5,8 @@
            java.util.Collections
            cryogen_core.markup.Markup))
 
+(def ^:private ^:static adoc (Asciidoctor$Factory/create))
+
 (defn asciidoc
   "Returns an Asciidoc (http://asciidoc.org/) implementation of the
   Markup protocol."
@@ -15,7 +17,7 @@
     (render-fn [this]
       (fn [rdr config]
         (->>
-          (.convert (Asciidoctor$Factory/create)
+          (.convert adoc
                    (->> (java.io.BufferedReader. rdr)
                         (line-seq)
                         (s/join "\n"))


### PR DESCRIPTION
Assign the Asciidoctor instance created by `(Asciidoctor$Factory/create)` to a static variable for reuse in the `render-fn`. This will speed up performance drastically.
