### PR TITLE
set SAFE mode to use callouts like circled numbers

### DIFF
--- a/src/cryogen_asciidoc/core.clj
+++ b/src/cryogen_asciidoc/core.clj
@@ -23,7 +23,7 @@
                    (->> (java.io.BufferedReader. rdr)
                         (line-seq)
                         (s/join "\n"))
-                   {Options/SAFE (int 1)})
+                   {Options/SAFE (.getLevel SafeMode/SAFE)})
           (rewrite-hrefs (:blog-prefix config)))))))
 
 (defn init []

--- a/src/cryogen_asciidoc/core.clj
+++ b/src/cryogen_asciidoc/core.clj
@@ -2,6 +2,8 @@
   (:require [cryogen-core.markup :refer [rewrite-hrefs markup-registry]]
             [clojure.string :as s])
   (:import org.asciidoctor.Asciidoctor$Factory
+           org.asciidoctor.Options
+           org.asciidoctor.SafeMode
            java.util.Collections
            cryogen_core.markup.Markup))
 
@@ -21,7 +23,7 @@
                    (->> (java.io.BufferedReader. rdr)
                         (line-seq)
                         (s/join "\n"))
-                   (Collections/emptyMap))
+                   {Options/SAFE (int 1)})
           (rewrite-hrefs (:blog-prefix config)))))))
 
 (defn init []


### PR DESCRIPTION
AsciidoctorJ document says:

"We recommend you to set SAFE safe mode when rendering AsciiDoc documents using AsciidoctorJ to have almost all Asciidoctor features such as icons, include directive or retrieving content from URIs enabled."