### PR TITLE
Allow multiple extensions in AsciiDoc Markup.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject cryogen-asciidoc "0.1.5"
+(defproject cryogen-asciidoc "0.1.6"
   :description "AsciiDoc parser for Cryogen"
   :url "https://github.com/cryogen-project/cryogen-asciidoc"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [cryogen-core "0.1.25"]
+                 [cryogen-core "0.3.2"]
                  [org.asciidoctor/asciidoctorj "2.2.0"]])

--- a/src/cryogen_asciidoc/core.clj
+++ b/src/cryogen_asciidoc/core.clj
@@ -15,7 +15,7 @@
   []
   (reify Markup
     (dir [this] "asc")
-    (ext [this] ".asc")
+    (exts [this] #{".adoc" ".ad" ".asciidoc" ".asc"})
     (render-fn [this]
       (fn [rdr config]
         (->>


### PR DESCRIPTION
Addresses Issue #6 in this repo.
For the set of related PRs see the main PR on the `cryogen-core` repo.