### PR TITLE
Upgrade to AsciidoctorJ v3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["resources"  ; needs to be in `paths` otherwise sys.classloader doesn't find plugin.edn
+         "src" ]
+ :deps {cryogen-core/cryogen-core {:mvn/version "0.4.4"}
+        ;; BEWARE: keep in sync with project.clj
+        org.asciidoctor/asciidoctorj {:mvn/version "3.0.0-alpha.1"}}
+ }

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,9 @@
-(defproject cryogen-asciidoc "0.3.4"
+(defproject cryogen-asciidoc "1.0.0"
   :description "AsciiDoc parser for Cryogen"
   :url "https://github.com/cryogen-project/cryogen-asciidoc"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [cryogen-core "0.3.2"]
-                 [org.asciidoctor/asciidoctorj "2.5.3"]])
+                 [cryogen-core "0.4.4"]
+                 ;; ;; BEWARE: keep in sync with deps.edn
+                 [org.asciidoctor/asciidoctorj "3.0.0-alpha.1"]])

--- a/src/cryogen_asciidoc/core.clj
+++ b/src/cryogen_asciidoc/core.clj
@@ -48,27 +48,40 @@
   ([a b & more]
    (reduce deep-merge (or a {}) (cons b more))))
 
+(defn options-map->Options [{:keys [attributes] :as opts-map}]
+  (let [opts (-> (Options/builder)
+                (.build))]
+    (doseq [[k v] (dissoc opts-map :attributes)]
+      (.setOption opts k v))
+    (some->> attributes (.setAttributes opts))
+    opts))
+
+(defn asciidoc-opts ^Options [{:keys [asciidoctor debug? page-meta] :as config}]
+  (let [opts-map
+        (deep-merge
+         {Options/SAFE (.getLevel SafeMode/SAFE)}
+         (keys->strings asciidoctor)
+         (keys->strings (:asciidoctor page-meta)))]
+    (when debug?
+      (println "DEBUG cryogen-asciidoc: options =" opts-map))
+    (options-map->Options opts-map)))
+
 (defn asciidoc
   "Returns an Asciidoc (http://asciidoc.org/) implementation of the
   Markup protocol."
   []
   (reify Markup
-    (dir [this] "asc")
-    (exts [this] #{".adoc" ".ad" ".asciidoc" ".asc"})
-    (render-fn [this]
+    (dir [_this] "asc")
+    (exts [_this] #{".adoc" ".ad" ".asciidoc" ".asc"})
+    (render-fn [_this]
       (fn [rdr config]
         (->>
-          (.convert (get-or-init-adoc adoc (:asciidoctor config))
+         (.convert (get-or-init-adoc adoc (:asciidoctor config))
                    (->> (java.io.BufferedReader. rdr)
                         (line-seq)
                         (s/join "\n"))
-                   (deep-merge
-                     {Options/SAFE (.getLevel SafeMode/SAFE)}
-                     (keys->strings
-                       (:asciidoctor config))
-                     (keys->strings
-                       (-> config :page-meta :asciidoctor))))
-          (rewrite-hrefs (:blog-prefix config)))))))
+                   (asciidoc-opts config))
+         (rewrite-hrefs (:blog-prefix config)))))))
 
 (defn init []
   (swap! markup-registry conj (asciidoc)))

--- a/src/cryogen_asciidoc/core.clj
+++ b/src/cryogen_asciidoc/core.clj
@@ -60,7 +60,7 @@
   (let [opts-map
         (deep-merge
          {Options/SAFE (.getLevel SafeMode/SAFE)}
-         (keys->strings asciidoctor)
+         (keys->strings (dissoc asciidoctor :extensions))
          (keys->strings (:asciidoctor page-meta)))]
     (when debug?
       (println "DEBUG cryogen-asciidoc: options =" opts-map))


### PR DESCRIPTION
Upgrade to the latest AsciidoctorJ v3.0.

Also, add deps.edn for easier inclusion in deps-based projects.

Bump version of the plugin itself to 1 - it has been stable for a long time.

Key code changes:

* Use the OptionsBuilder -> Options (though as little as possible) instead of the
  deprecated map argument.
* When cryogen's `:debug?` is on, print the final options - useful in troubleshooting

See https://github.com/asciidoctor/asciidoctorj/blob/main/CHANGELOG.adoc for more info. There are some minor breaking changes compared to v2.5, the main one being likely that Java >=11 is not required.